### PR TITLE
feat: split_io (!Send)

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,3 +1,4 @@
 max_width = 80
 tab_spaces = 2
-edition = "2018"
+edition = "2021"
+imports_granularity = "Item"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 tokio = { version = "1", features = ["rt"] }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt"] }
+tokio = { version = "1", features = ["io-util", "macros", "rt"] }
 
 [lib]
 name = "deno_unsync"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deno_unsync"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["the Deno authors"]
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod flag;
 mod joinset;
+mod split;
 mod task;
 mod task_queue;
 
@@ -12,3 +13,10 @@ pub use task::MaskFutureAsSend;
 pub use task_queue::TaskQueue;
 pub use task_queue::TaskQueuePermit;
 pub use task_queue::TaskQueuePermitAcquireFuture;
+pub use split::split_io;
+pub use split::IOReadHalf;
+pub use split::IOWriteHalf;
+
+/// Marker for items that are ![`Send`].
+#[derive(Copy, Clone, Default, Eq, PartialEq, PartialOrd, Ord, Debug, Hash)]
+pub struct UnsendMarker(std::marker::PhantomData<std::sync::MutexGuard<'static, ()>>);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@ mod task_queue;
 
 pub use flag::Flag;
 pub use joinset::JoinSet;
+pub use split::split_io;
+pub use split::IOReadHalf;
+pub use split::IOWriteHalf;
 pub use task::spawn;
 pub use task::spawn_blocking;
 pub use task::JoinHandle;
@@ -13,10 +16,9 @@ pub use task::MaskFutureAsSend;
 pub use task_queue::TaskQueue;
 pub use task_queue::TaskQueuePermit;
 pub use task_queue::TaskQueuePermitAcquireFuture;
-pub use split::split_io;
-pub use split::IOReadHalf;
-pub use split::IOWriteHalf;
 
 /// Marker for items that are ![`Send`].
 #[derive(Copy, Clone, Default, Eq, PartialEq, PartialOrd, Ord, Debug, Hash)]
-pub struct UnsendMarker(std::marker::PhantomData<std::sync::MutexGuard<'static, ()>>);
+pub struct UnsendMarker(
+  std::marker::PhantomData<std::sync::MutexGuard<'static, ()>>,
+);

--- a/src/split.rs
+++ b/src/split.rs
@@ -1,0 +1,159 @@
+use crate::UnsendMarker;
+use std::cell::Cell;
+use std::cell::UnsafeCell;
+use std::pin::Pin;
+use std::rc::Rc;
+use std::task::Poll;
+use tokio::io::AsyncRead;
+use tokio::io::AsyncWrite;
+
+/// Create a !Send I/O split on top of a stream.
+pub fn split_io<S>(stream: S) -> (IOReadHalf<S>, IOWriteHalf<S>)
+where
+  S: AsyncRead + AsyncWrite + Unpin,
+{
+  let is_write_vectored = stream.is_write_vectored();
+  let stream = Rc::new(Split {
+    stream: UnsafeCell::new(stream),
+    lock: Cell::new(false),
+  });
+  (
+    IOReadHalf {
+      split: stream.clone(),
+      _marker: UnsendMarker::default(),
+    },
+    IOWriteHalf {
+      split: stream,
+      is_write_vectored,
+      _marker: UnsendMarker::default(),
+    },
+  )
+}
+
+struct Split<S> {
+  stream: UnsafeCell<S>,
+  lock: Cell<bool>,
+}
+
+pub struct IOReadHalf<S> {
+  split: Rc<Split<S>>,
+  _marker: UnsendMarker,
+}
+
+pub struct IOWriteHalf<S> {
+  split: Rc<Split<S>>,
+  is_write_vectored: bool,
+  _marker: UnsendMarker,
+}
+
+impl<S> AsyncRead for IOReadHalf<S>
+where
+  S: AsyncRead + Unpin,
+{
+  fn poll_read(
+    self: std::pin::Pin<&mut Self>,
+    cx: &mut std::task::Context<'_>,
+    buf: &mut tokio::io::ReadBuf<'_>,
+  ) -> std::task::Poll<std::io::Result<()>> {
+    let lock = &self.split.lock;
+    if lock.clone().into_inner() {
+      return Poll::Ready(Err(std::io::Error::new(
+        std::io::ErrorKind::PermissionDenied,
+        "Re-entrant read while writing",
+      )));
+    }
+    lock.set(true);
+    // SAFETY: This is !Send and the lock is set, so we can guarantee we won't get another &mut to the stream now
+    let s = unsafe { self.split.stream.get().as_mut().unwrap() };
+    let res = Pin::new(s).poll_read(cx, buf);
+    lock.set(false);
+    res
+  }
+}
+
+impl<S> AsyncWrite for IOWriteHalf<S>
+where
+  S: AsyncWrite + Unpin,
+{
+  fn poll_flush(
+    self: std::pin::Pin<&mut Self>,
+    cx: &mut std::task::Context<'_>,
+  ) -> std::task::Poll<Result<(), std::io::Error>> {
+    let lock = &self.split.lock;
+    if lock.clone().into_inner() {
+      return Poll::Ready(Err(std::io::Error::new(
+        std::io::ErrorKind::PermissionDenied,
+        "Re-entrant write while reading",
+      )));
+    }
+    lock.set(true);
+    // SAFETY: This is !Send and the lock is set, so we can guarantee we won't get another &mut to the stream now
+    let s = unsafe { self.split.stream.get().as_mut().unwrap() };
+    let res = Pin::new(s).poll_flush(cx);
+    lock.set(false);
+    res
+  }
+
+  fn poll_shutdown(
+    self: std::pin::Pin<&mut Self>,
+    cx: &mut std::task::Context<'_>,
+  ) -> std::task::Poll<Result<(), std::io::Error>> {
+    let lock = &self.split.lock;
+    if lock.clone().into_inner() {
+      return Poll::Ready(Err(std::io::Error::new(
+        std::io::ErrorKind::PermissionDenied,
+        "Re-entrant write while reading",
+      )));
+    }
+    lock.set(true);
+    // SAFETY: This is !Send and the lock is set, so we can guarantee we won't get another &mut to the stream now
+    let s = unsafe { self.split.stream.get().as_mut().unwrap() };
+    let res = Pin::new(s).poll_shutdown(cx);
+    lock.set(false);
+    res
+  }
+
+  fn poll_write(
+    self: std::pin::Pin<&mut Self>,
+    cx: &mut std::task::Context<'_>,
+    buf: &[u8],
+  ) -> std::task::Poll<Result<usize, std::io::Error>> {
+    let lock = &self.split.lock;
+    if lock.clone().into_inner() {
+      return Poll::Ready(Err(std::io::Error::new(
+        std::io::ErrorKind::PermissionDenied,
+        "Re-entrant write while reading",
+      )));
+    }
+    lock.set(true);
+    // SAFETY: This is !Send and the lock is set, so we can guarantee we won't get another &mut to the stream now
+    let s = unsafe { self.split.stream.get().as_mut().unwrap() };
+    let res = Pin::new(s).poll_write(cx, buf);
+    lock.set(false);
+    res
+  }
+
+  fn poll_write_vectored(
+    self: std::pin::Pin<&mut Self>,
+    cx: &mut std::task::Context<'_>,
+    bufs: &[std::io::IoSlice<'_>],
+  ) -> std::task::Poll<Result<usize, std::io::Error>> {
+    let lock = &self.split.lock;
+    if lock.clone().into_inner() {
+      return Poll::Ready(Err(std::io::Error::new(
+        std::io::ErrorKind::PermissionDenied,
+        "Re-entrant write while reading",
+      )));
+    }
+    lock.set(true);
+    // SAFETY: This is !Send and the lock is set, so we can guarantee we won't get another &mut to the stream now
+    let s = unsafe { self.split.stream.get().as_mut().unwrap() };
+    let res = Pin::new(s).poll_write_vectored(cx, bufs);
+    lock.set(false);
+    res
+  }
+
+  fn is_write_vectored(&self) -> bool {
+    self.is_write_vectored
+  }
+}

--- a/src/split.rs
+++ b/src/split.rs
@@ -157,3 +157,23 @@ where
     self.is_write_vectored
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use tokio::io::AsyncReadExt;
+  use tokio::io::AsyncWriteExt;
+
+  #[tokio::test(flavor = "current_thread")]
+  async fn split_duplex() {
+    let (a, b) = tokio::io::duplex(1024);
+    let (mut ar, mut aw) = split_io(a);
+    let (mut br, mut bw) = split_io(b);
+
+    bw.write_i8(123).await.unwrap();
+    assert_eq!(ar.read_i8().await.unwrap(), 123);
+
+    aw.write_i8(123).await.unwrap();
+    assert_eq!(br.read_i8().await.unwrap(), 123);
+  }
+}

--- a/src/split.rs
+++ b/src/split.rs
@@ -7,7 +7,8 @@ use std::task::Poll;
 use tokio::io::AsyncRead;
 use tokio::io::AsyncWrite;
 
-/// Create a !Send I/O split on top of a stream.
+/// Create a ![`Send`] I/O split on top of a stream. The split reader and writer halves are safe to use
+/// only in a single-threaded context, and are not legal to send to another thread.
 pub fn split_io<S>(stream: S) -> (IOReadHalf<S>, IOWriteHalf<S>)
 where
   S: AsyncRead + AsyncWrite + Unpin,


### PR DESCRIPTION
This is similar to tokio's I/O split, but not thread-safe.