### PR TITLE
feat: `SharedLocal` future

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,8 +15,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+    - uses: dsherret/rust-toolchain-file@v1
+    - run: rustup install nightly
+    - run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu miri
     - name: Build
       run: cargo build --verbose
+    - name: Format
+      run: cargo fmt -- --check
+    - name: Lint
+      run: cargo clippy --all-targets --all-features -- -D warnings
     - name: Run tests
       run: cargo test --verbose
+    - name: Run tests (miri)
+      run: cargo +nightly miri test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,21 +11,24 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
     - uses: dsherret/rust-toolchain-file@v1
-    - run: rustup install nightly
-    - run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu miri
     - name: Build
-      run: cargo build --verbose
+      run: cargo build
     - name: Format
       run: cargo fmt -- --check
     - name: Lint
       run: cargo clippy --all-targets --all-features -- -D warnings
-    - name: Run tests
+    - name: Test
       run: cargo test --verbose
-    - name: Run tests (miri)
+
+  miri:
+    runs-on: ubuntu-latest
+    - uses: actions/checkout@v4
+    - run: rustup install nightly
+    - run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu miri
+    - name: Tests (miri)
       run: cargo +nightly miri test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,6 +27,8 @@ jobs:
 
   miri:
     runs-on: ubuntu-latest
+
+    steps:
     - uses: actions/checkout@v4
     - run: rustup install nightly
     - run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu miri

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,4 +33,5 @@ jobs:
     - run: rustup install nightly
     - run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu miri
     - name: Tests (miri)
-      run: cargo +nightly miri test
+      # opt into only specific tests because this takes a while to run
+      run: cargo +nightly miri test future

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,4 +34,4 @@ jobs:
     - run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu miri
     - name: Tests (miri)
       # opt into only specific tests because this takes a while to run
-      run: cargo +nightly miri test future
+      run: cargo +nightly miri test future::test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 tokio = { version = "1", features = ["rt"] }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["io-util", "macros", "rt", "time"] }
+tokio = { version = "1", features = ["io-util", "macros", "rt", "sync"] }
 
 [lib]
 name = "deno_unsync"

--- a/src/flag.rs
+++ b/src/flag.rs
@@ -8,6 +8,11 @@ use std::cell::Cell;
 pub struct Flag(Cell<bool>);
 
 impl Flag {
+  /// Creates a new flag that's raised.
+  pub fn raised() -> Self {
+    Self(Cell::new(true))
+  }
+
   /// Raises the flag returning if raised.
   pub fn raise(&self) -> bool {
     !self.0.replace(true)

--- a/src/future.rs
+++ b/src/future.rs
@@ -226,21 +226,21 @@ mod test {
 
   use super::LocalFutureExt;
 
-  #[tokio::test]
+  #[tokio::test(flavor = "current_thread")]
   async fn test_shared_local_future() {
     let shared = super::SharedLocal::new(Box::pin(async { 42 }));
     assert_eq!(shared.clone().await, 42);
     assert_eq!(shared.await, 42);
   }
 
-  #[tokio::test]
+  #[tokio::test(flavor = "current_thread")]
   async fn test_shared_local() {
     let shared = async { 42 }.shared_local();
     assert_eq!(shared.clone().await, 42);
     assert_eq!(shared.await, 42);
   }
 
-  #[tokio::test]
+  #[tokio::test(flavor = "current_thread")]
   async fn multiple_tasks_waiting() {
     let notify = Arc::new(Notify::new());
 

--- a/src/future.rs
+++ b/src/future.rs
@@ -63,7 +63,9 @@ impl<TFuture: Future<Output = TOutput>, TOutput: Clone>
   SharedLocal<TFuture, TOutput>
 {
   pub fn new(future: TFuture) -> Self {
-    SharedLocal(Rc::new(RefCell::new(FutureOrResult::Future(Box::pin(future)))))
+    SharedLocal(Rc::new(RefCell::new(FutureOrResult::Future(Box::pin(
+      future,
+    )))))
   }
 }
 
@@ -80,14 +82,13 @@ impl<TFuture: Future<Output = TOutput>, TOutput: Clone> std::future::Future
 
     let mut inner = self.0.borrow_mut();
     match &mut *inner {
-      FutureOrResult::Future(fut) => {
-        match fut.as_mut().poll(cx) {
+      FutureOrResult::Future(fut) => match fut.as_mut().poll(cx) {
         Poll::Ready(result) => {
           *inner = FutureOrResult::Result(result.clone());
           Poll::Ready(result)
         }
         Poll::Pending => Poll::Pending,
-      }},
+      },
       FutureOrResult::Result(result) => Poll::Ready(result.clone()),
     }
   }

--- a/src/future.rs
+++ b/src/future.rs
@@ -4,61 +4,118 @@ use std::cell::RefCell;
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
+use std::task::Context;
+use std::task::RawWaker;
+use std::task::RawWakerVTable;
+use std::task::Waker;
+
+use crate::Flag;
 
 impl<T: ?Sized> LocalFutureExt for T where T: Future {}
 
 pub trait LocalFutureExt: std::future::Future {
-  fn shared_local(self) -> SharedLocal<Self::Output>
+  fn shared_local(self) -> SharedLocal<Self>
   where
-    Self: Sized + 'static,
+    Self: Sized,
     Self::Output: Clone,
   {
-    SharedLocal::new(Box::pin(self))
+    SharedLocal::new(self)
   }
 }
 
-enum FutureOrResult<TOutput: Clone> {
-  Future(Pin<Box<dyn Future<Output = TOutput>>>),
-  Result(TOutput),
+enum FutureOrOutput<TFuture: Future> {
+  Future(TFuture),
+  Output(TFuture::Output),
 }
 
-impl<TOutput: Clone + std::fmt::Debug> std::fmt::Debug
-  for FutureOrResult<TOutput>
+impl<TFuture: Future> std::fmt::Debug for FutureOrOutput<TFuture>
+where
+  TFuture::Output: std::fmt::Debug,
 {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match self {
       Self::Future(_) => f.debug_tuple("Future").field(&"<pending>").finish(),
-      Self::Result(arg0) => f.debug_tuple("Result").field(arg0).finish(),
+      Self::Output(arg0) => f.debug_tuple("Result").field(arg0).finish(),
     }
+  }
+}
+
+struct SharedLocalData<TFuture: Future> {
+  future_or_output: FutureOrOutput<TFuture>,
+}
+
+impl<TFuture: Future> std::fmt::Debug for SharedLocalData<TFuture>
+where
+  TFuture::Output: std::fmt::Debug,
+{
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("SharedLocalData")
+      .field("future_or_output", &self.future_or_output)
+      .finish()
+  }
+}
+
+struct SharedLocalInner<TFuture: Future> {
+  data: RefCell<SharedLocalData<TFuture>>,
+  child_waker_state: Rc<ChildWakerState>,
+}
+
+impl<TFuture: Future> std::fmt::Debug for SharedLocalInner<TFuture>
+where
+  TFuture::Output: std::fmt::Debug,
+{
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("SharedLocalInner")
+      .field("data", &self.data)
+      .field("child_waker_state", &self.child_waker_state)
+      .finish()
   }
 }
 
 /// A !Send-friendly future whose result can be awaited multiple times.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct SharedLocal<TOutput: Clone>(Rc<RefCell<FutureOrResult<TOutput>>>);
+pub struct SharedLocal<TFuture: Future>(Rc<SharedLocalInner<TFuture>>);
 
-impl<TOutput: Clone> Clone for SharedLocal<TOutput> {
+impl<TFuture: Future> Clone for SharedLocal<TFuture>
+where
+  TFuture::Output: Clone,
+{
   fn clone(&self) -> Self {
     Self(self.0.clone())
   }
 }
 
-impl<TOutput: Clone + std::fmt::Debug> std::fmt::Debug
-  for SharedLocal<TOutput>
+impl<TFuture: Future> std::fmt::Debug for SharedLocal<TFuture>
+where
+  TFuture::Output: std::fmt::Debug,
 {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.debug_tuple("SharedLocal").field(&self.0).finish()
   }
 }
 
-impl<TOutput: Clone> SharedLocal<TOutput> {
-  pub fn new(future: Pin<Box<dyn Future<Output = TOutput>>>) -> Self {
-    SharedLocal(Rc::new(RefCell::new(FutureOrResult::Future(future))))
+impl<TFuture: Future> SharedLocal<TFuture>
+where
+  TFuture::Output: Clone,
+{
+  pub fn new(future: TFuture) -> Self {
+    SharedLocal(Rc::new(SharedLocalInner {
+      data: RefCell::new(SharedLocalData {
+        future_or_output: FutureOrOutput::Future(future),
+      }),
+      child_waker_state: Rc::new(ChildWakerState {
+        can_poll: Flag::raised(),
+        wakers: RefCell::new(Vec::new()),
+      }),
+    }))
   }
 }
 
-impl<TOutput: Clone> std::future::Future for SharedLocal<TOutput> {
-  type Output = TOutput;
+impl<TFuture: Future> std::future::Future for SharedLocal<TFuture>
+where
+  TFuture::Output: Clone,
+{
+  type Output = TFuture::Output;
 
   fn poll(
     self: std::pin::Pin<&mut Self>,
@@ -66,22 +123,107 @@ impl<TOutput: Clone> std::future::Future for SharedLocal<TOutput> {
   ) -> std::task::Poll<Self::Output> {
     use std::task::Poll;
 
-    let mut inner = self.0.borrow_mut();
-    match &mut *inner {
-      FutureOrResult::Future(fut) => match fut.as_mut().poll(cx) {
-        Poll::Ready(result) => {
-          *inner = FutureOrResult::Result(result.clone());
-          Poll::Ready(result)
+    let mut inner = self.0.data.borrow_mut();
+    match &mut inner.future_or_output {
+      FutureOrOutput::Future(fut) => {
+        self
+          .0
+          .child_waker_state
+          .wakers
+          .borrow_mut()
+          .push(cx.waker().clone());
+        if self.0.child_waker_state.can_poll.lower() {
+          let child_waker =
+            create_child_waker(self.0.child_waker_state.clone());
+          let mut child_cx = Context::from_waker(&child_waker);
+          let fut = unsafe { Pin::new_unchecked(fut) };
+          match fut.poll(&mut child_cx) {
+            Poll::Ready(result) => {
+              inner.future_or_output = FutureOrOutput::Output(result.clone());
+              drop(inner); // stop borrow_mut
+              let wakers = std::mem::take(
+                &mut *self.0.child_waker_state.wakers.borrow_mut(),
+              );
+              for waker in wakers {
+                waker.wake();
+              }
+              Poll::Ready(result)
+            }
+            Poll::Pending => Poll::Pending,
+          }
+        } else {
+          Poll::Pending
         }
-        Poll::Pending => Poll::Pending,
-      },
-      FutureOrResult::Result(result) => Poll::Ready(result.clone()),
+      }
+      FutureOrOutput::Output(result) => Poll::Ready(result.clone()),
     }
   }
 }
 
+#[derive(Debug)]
+struct ChildWakerState {
+  can_poll: Flag,
+  wakers: RefCell<Vec<Waker>>,
+}
+
+fn create_child_waker(state: Rc<ChildWakerState>) -> Waker {
+  let raw_waker = RawWaker::new(
+    Rc::into_raw(state) as *const (),
+    &RawWakerVTable::new(
+      clone_waker,
+      wake_waker,
+      wake_by_ref_waker,
+      drop_waker,
+    ),
+  );
+  unsafe { Waker::from_raw(raw_waker) }
+}
+
+unsafe fn clone_waker(data: *const ()) -> RawWaker {
+  Rc::increment_strong_count(data as *const ChildWakerState);
+  RawWaker::new(
+    data,
+    &RawWakerVTable::new(
+      clone_waker,
+      wake_waker,
+      wake_by_ref_waker,
+      drop_waker,
+    ),
+  )
+}
+
+unsafe fn wake_waker(data: *const ()) {
+  let state = Rc::from_raw(data as *const ChildWakerState);
+  let wakers = {
+    state.can_poll.raise();
+    let mut wakers = state.wakers.borrow_mut();
+    std::mem::take(&mut *wakers)
+  };
+  for waker in wakers {
+    waker.wake();
+  }
+}
+
+unsafe fn wake_by_ref_waker(data: *const ()) {
+  let state = Rc::from_raw(data as *const ChildWakerState);
+  state.can_poll.raise();
+  let wakers = state.wakers.borrow().clone();
+  for waker in wakers {
+    waker.wake_by_ref();
+  }
+  let _ = Rc::into_raw(state); // keep it alive
+}
+
+unsafe fn drop_waker(data: *const ()) {
+  Rc::decrement_strong_count(data as *const ChildWakerState);
+}
+
 #[cfg(test)]
 mod test {
+  use std::sync::Arc;
+
+  use tokio::sync::Notify;
+
   use super::LocalFutureExt;
 
   #[tokio::test]
@@ -96,5 +238,34 @@ mod test {
     let shared = async { 42 }.shared_local();
     assert_eq!(shared.clone().await, 42);
     assert_eq!(shared.await, 42);
+  }
+
+  #[tokio::test]
+  async fn multiple_tasks_waiting() {
+    let notify = Arc::new(Notify::new());
+
+    let shared = {
+      let notify = notify.clone();
+      async move {
+        tokio::task::yield_now().await;
+        notify.notified().await;
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+      }
+      .shared_local()
+    };
+    let mut tasks = Vec::new();
+    for _ in 0..10 {
+      tasks.push(crate::spawn(shared.clone()));
+    }
+
+    crate::spawn(async move {
+      notify.notify_one();
+      for task in tasks {
+        task.await.unwrap();
+      }
+    })
+    .await
+    .unwrap()
   }
 }

--- a/src/future.rs
+++ b/src/future.rs
@@ -35,6 +35,7 @@ impl<
   }
 }
 
+/// A !Send-friendly future whose result can be awaited multiple times.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct SharedLocal<TFuture: Future<Output = TOutput>, TOutput: Clone>(
   Rc<RefCell<FutureOrResult<TFuture, TOutput>>>,

--- a/src/future.rs
+++ b/src/future.rs
@@ -1,0 +1,112 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+use std::cell::RefCell;
+use std::future::Future;
+use std::pin::Pin;
+use std::rc::Rc;
+
+impl<T: ?Sized> LocalFutureExt for T where T: Future {}
+
+pub trait LocalFutureExt: std::future::Future {
+  fn shared_local(self) -> SharedLocal<Self, Self::Output>
+  where
+    Self: Sized,
+    Self::Output: Clone,
+  {
+    SharedLocal::new(self)
+  }
+}
+
+enum FutureOrResult<TFuture: Future<Output = TOutput>, TOutput: Clone> {
+  Future(Pin<Box<TFuture>>),
+  Result(TOutput),
+}
+
+impl<
+    TFuture: Future<Output = TOutput> + std::fmt::Debug,
+    TOutput: Clone + std::fmt::Debug,
+  > std::fmt::Debug for FutureOrResult<TFuture, TOutput>
+{
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      Self::Future(arg0) => f.debug_tuple("Future").field(arg0).finish(),
+      Self::Result(arg0) => f.debug_tuple("Result").field(arg0).finish(),
+    }
+  }
+}
+
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct SharedLocal<TFuture: Future<Output = TOutput>, TOutput: Clone>(
+  Rc<RefCell<FutureOrResult<TFuture, TOutput>>>,
+);
+
+impl<TFuture: Future<Output = TOutput>, TOutput: Clone> Clone
+  for SharedLocal<TFuture, TOutput>
+{
+  fn clone(&self) -> Self {
+    Self(self.0.clone())
+  }
+}
+
+impl<
+    TFuture: Future<Output = TOutput> + std::fmt::Debug,
+    TOutput: Clone + std::fmt::Debug,
+  > std::fmt::Debug for SharedLocal<TFuture, TOutput>
+{
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_tuple("SharedLocal").field(&self.0).finish()
+  }
+}
+
+impl<TFuture: Future<Output = TOutput>, TOutput: Clone>
+  SharedLocal<TFuture, TOutput>
+{
+  pub fn new(future: TFuture) -> Self {
+    SharedLocal(Rc::new(RefCell::new(FutureOrResult::Future(Box::pin(future)))))
+  }
+}
+
+impl<TFuture: Future<Output = TOutput>, TOutput: Clone> std::future::Future
+  for SharedLocal<TFuture, TOutput>
+{
+  type Output = TOutput;
+
+  fn poll(
+    self: std::pin::Pin<&mut Self>,
+    cx: &mut std::task::Context<'_>,
+  ) -> std::task::Poll<Self::Output> {
+    use std::task::Poll;
+
+    let mut inner = self.0.borrow_mut();
+    match &mut *inner {
+      FutureOrResult::Future(fut) => {
+        match fut.as_mut().poll(cx) {
+        Poll::Ready(result) => {
+          *inner = FutureOrResult::Result(result.clone());
+          Poll::Ready(result)
+        }
+        Poll::Pending => Poll::Pending,
+      }},
+      FutureOrResult::Result(result) => Poll::Ready(result.clone()),
+    }
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use super::LocalFutureExt;
+
+  #[tokio::test]
+  async fn test_shared_local_future() {
+    let shared = super::SharedLocal::new(async { 42 });
+    assert_eq!(shared.clone().await, 42);
+    assert_eq!(shared.await, 42);
+  }
+
+  #[tokio::test]
+  async fn test_shared_local() {
+    let shared = async { 42 }.shared_local();
+    assert_eq!(shared.clone().await, 42);
+    assert_eq!(shared.await, 42);
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
 mod flag;
+pub mod future;
 mod joinset;
 pub mod mpsc;
 mod split;

--- a/src/task_queue.rs
+++ b/src/task_queue.rs
@@ -168,15 +168,15 @@ impl Future for TaskQueuePermitAcquireFuture {
 
 #[cfg(test)]
 mod tests {
-  use std::sync::Arc;
-  use std::sync::Mutex;
-
   use crate::JoinSet;
 
   use super::*;
 
   #[tokio::test]
   async fn task_queue_runs_one_after_other() {
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
     let task_queue = Rc::new(TaskQueue::default());
     let mut set = JoinSet::default();
     let data = Arc::new(Mutex::new(0));

--- a/src/task_queue.rs
+++ b/src/task_queue.rs
@@ -168,15 +168,15 @@ impl Future for TaskQueuePermitAcquireFuture {
 
 #[cfg(test)]
 mod tests {
+  use std::sync::Arc;
+  use std::sync::Mutex;
+
   use crate::JoinSet;
 
   use super::*;
 
   #[tokio::test]
   async fn task_queue_runs_one_after_other() {
-    use std::sync::Arc;
-    use std::sync::Mutex;
-
     let task_queue = Rc::new(TaskQueue::default());
     let mut set = JoinSet::default();
     let data = Arc::new(Mutex::new(0));


### PR DESCRIPTION
I need this in some CLI code because `.shared()` requires `Send`.

Closes https://github.com/denoland/deno_unsync/issues/6