### PR TITLE
fix: replace `futures` with `futures-util`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default = ["tokio"]
 tokio = ["dep:tokio"]
 
 [dependencies]
-futures = "0.3.21"
+futures-util = { version = "0.3.21", default-features = false, features = ["std"] }
 parking_lot = "0.12.3"
 tokio = { version = "1", features = ["rt"], optional = true }
 

--- a/src/sync/task_queue.rs
+++ b/src/sync/task_queue.rs
@@ -4,7 +4,7 @@ use std::collections::LinkedList;
 use std::future::Future;
 use std::sync::Arc;
 
-use futures::task::AtomicWaker;
+use futures_util::task::AtomicWaker;
 use parking_lot::Mutex;
 
 use super::AtomicFlag;
@@ -169,7 +169,7 @@ mod test {
         .unwrap();
       }));
     }
-    futures::future::join_all(tasks).await;
+    futures_util::future::join_all(tasks).await;
   }
 
   #[tokio::test]

--- a/src/sync/value_creator.rs
+++ b/src/sync/value_creator.rs
@@ -2,10 +2,10 @@
 
 use std::sync::Arc;
 
-use futures::future::BoxFuture;
-use futures::future::LocalBoxFuture;
-use futures::future::Shared;
-use futures::FutureExt;
+use futures_util::future::BoxFuture;
+use futures_util::future::LocalBoxFuture;
+use futures_util::future::Shared;
+use futures_util::FutureExt;
 use parking_lot::Mutex;
 use tokio::task::JoinError;
 


### PR DESCRIPTION
This replaces `futures` with `futures-util`, which is what we were using before through the re-exports in `futures`. This reduces the number of dependencies.