### PR TITLE
Replace spawn_blocking with spawn_blocking_optional and spawn_blocking_always

### DIFF
--- a/src/sync/task_queue.rs
+++ b/src/sync/task_queue.rs
@@ -160,7 +160,7 @@ mod test {
     for i in 0..100 {
       let data = data.clone();
       tasks.push(task_queue.run(async move {
-        crate::spawn_blocking(move || {
+        crate::spawn_blocking_optional(move || {
           let mut data = data.lock();
           assert_eq!(*data, i);
           *data = i + 1;

--- a/src/task_queue.rs
+++ b/src/task_queue.rs
@@ -186,7 +186,7 @@ mod tests {
       let acquire = task_queue.acquire();
       set.spawn(async move {
         let permit = acquire.await;
-        crate::spawn_blocking(move || {
+        crate::spawn_blocking_always(move || {
           let mut data = data.lock().unwrap();
           assert_eq!(i, *data);
           *data = i + 1;

--- a/src/tokio/mod.rs
+++ b/src/tokio/mod.rs
@@ -5,9 +5,12 @@ pub use split::split_io;
 pub use split::IOReadHalf;
 pub use split::IOWriteHalf;
 
+pub use task::set_spawn_blocking_optional_use_current_thread;
 pub use task::spawn;
-pub use task::spawn_blocking;
+pub use task::spawn_blocking_always;
+pub use task::spawn_blocking_optional;
 pub use task::JoinHandle;
+pub use task::JoinResult;
 pub use task::MaskFutureAsSend;
 
 mod joinset;

--- a/src/tokio/task.rs
+++ b/src/tokio/task.rs
@@ -5,6 +5,7 @@ use core::task::Context;
 use core::task::Poll;
 use std::future::Future;
 use std::marker::PhantomData;
+use std::sync::OnceLock;
 use tokio::runtime::Handle;
 use tokio::runtime::RuntimeFlavor;
 
@@ -64,10 +65,28 @@ pub fn spawn<F: Future<Output = R> + 'static, R: 'static>(
   }
 }
 
-/// Equivalent to [`tokio::task::spawn_blocking`]. Currently a thin wrapper around the tokio API, but this
-/// may change in the future.
+/// Deprecated. Use [`spawn_blocking_always`] when running on another thread is necessary for correctness.
+/// Use [`spawn_blocking_optional`] to allow running on the current thread when configured.
 #[inline(always)]
+#[deprecated(
+  since = "0.4.5",
+  note = "use spawn_blocking_always or spawn_blocking_optional as appropriate"
+)]
+#[allow(dead_code)]
 pub fn spawn_blocking<
+  F: (FnOnce() -> R) + Send + 'static,
+  R: Send + 'static,
+>(
+  f: F,
+) -> JoinHandle<R> {
+  spawn_blocking_always(f)
+}
+
+/// Equivalent to [`tokio::task::spawn_blocking`]. Use when the provided closure must be run on another
+/// thread for correctness. Use [`spawn_blocking_optional`] to allow running on the current thread when
+/// configured. Currently a thin wrapper around the tokio API, but this may change in the future.
+#[inline(always)]
+pub fn spawn_blocking_always<
   F: (FnOnce() -> R) + Send + 'static,
   R: Send + 'static,
 >(
@@ -77,6 +96,37 @@ pub fn spawn_blocking<
   JoinHandle {
     handle,
     _r: Default::default(),
+  }
+}
+
+pub type JoinResult<T> = Result<T, tokio::task::JoinError>;
+
+static OPTIONAL_USE_CURRENT_THREAD: OnceLock<bool> = OnceLock::new();
+
+/// Configure whether [`spawn_blocking_optional`] should run on current thread.
+pub fn set_spawn_blocking_optional_use_current_thread(value: bool) {
+  //println!("XXX set_spawn_blocking_optional_use_current_thread({:?})", value);
+  OPTIONAL_USE_CURRENT_THREAD
+    .set(value)
+    .expect("value may only be set once");
+}
+
+/// Equivalent to [`tokio::task::spawn_blocking`] but may be configured to run on the current thread.
+/// Use [`spawn_blocking_always`] when running on another thread is necessary for correctness.
+/// Currently a thin wrapper around the tokio API, but this may change in the future.
+#[inline(always)]
+pub async fn spawn_blocking_optional<
+  F: (FnOnce() -> R) + Send + 'static,
+  R: Send + 'static,
+>(
+  f: F,
+) -> JoinResult<R> {
+  if *OPTIONAL_USE_CURRENT_THREAD.get_or_init(|| false) {
+    Ok(f())
+  } else {
+    let result =
+      tokio::task::spawn_blocking(|| MaskResultAsSend { result: f() }).await?;
+    Ok(result.into_inner())
   }
 }
 


### PR DESCRIPTION
Use spawn_blocking_always when running on another thread is necessary for correctness. Use spawn_blocking_optional to allow running on the current thread when configured.

spawn_blocking_optional is an async function to allow running the supplied function eagerly which is necessary for some usages.

Configuration is the responsibility of the app which should call `set_spawn_blocking_optional_use_current_thread` before first call to `spawn_blocking_optional`.

Associated deno PR: https://github.com/denoland/deno/pull/30221